### PR TITLE
anaconda-ai v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-ai" %}
-{% set version = "0.4.1" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/anaconda_ai-{{ version }}.tar.gz
-  sha256: c771d0f4af89bb11e999e40a9054e427652331d4a5a5dccd70a6ed8eb3d28832
+  sha256: 6a630a89c5b66499d423f12757ff4cb4facb4a0d64add78d5926894bcdc5094a
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -23,8 +23,8 @@ requirements:
     - pip
   run:
     - python
-    - anaconda-auth >=0.8
-    - anaconda-cli-base >=0.5
+    - anaconda-auth >=0.13.0
+    - anaconda-cli-base >=0.8.1
     - rich
     - pydantic >=2
     - typer
@@ -36,6 +36,8 @@ requirements:
   run_constrained:
     - langchain-openai >=0.2.8
     - llm >=0.22
+    - mcp >=1.26
+    - pydantic-ai >=1.50
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,10 @@ test:
     - pip check
   requires:
     - pip
+    # 'anaconda-auth' depends on 'anaconda-anon-usage'
+    # 'anaconda-anon-usage' requires 'conda' installed
+    # Otherwise, 'pip check' test fails
+    - conda >=23.9.0
 
 about:
   home: https://anaconda.cloud


### PR DESCRIPTION
anaconda-ai 0.5.0

**Destination channel:** defaults

### Links

- [PKG-13025](https://anaconda.atlassian.net/browse/PKG-13025) 
- [Upstream repository](https://github.com/anaconda/anaconda-ai/tree/v0.5.0)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-ai/releases/tag/v0.5.0)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Bump version and update pins as requested on the ticket.
- Add `conda` dependency to the tests due to `anaconda-anon-usage` requirements (see https://github.com/AnacondaRecipes/anaconda-ai-feedstock/pull/2#issuecomment-4079253299 for more details)
- Enable Python 3.14 builds


[PKG-13025]: https://anaconda.atlassian.net/browse/PKG-13025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ