### PR TITLE
anaconda-ai v0.5.0 b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - openai
     - platformdirs
     - packaging
-    - click <8.2
   run_constrained:
     - langchain-openai >=0.2.8
     - llm >=0.22

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   skip: true #[py<39]
 
 requirements:


### PR DESCRIPTION
Remove `click <8.2` as requested by the maintainer. There is a [request ticket](https://anaconda.atlassian.net/browse/PKG-13036) attached.
